### PR TITLE
Add the ability to specify extra-organizational acct IDs that can launch the AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,15 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| account\_name\_regex | A regular expression that will be applied against the names of all accounts in the AWS organization.  If the name of an account matches the regular expression, that account will be allowed to launch the specified AMI. | `string` | n/a | yes |
+| account\_name\_regex | A regular expression that will be applied against the names of all accounts in the AWS organization.  If the name of an account matches the regular expression, that account will be allowed to launch the specified AMI.  The default value should not match any valid account name. | `string` | `"^$"` | no |
 | ami\_id | The ID of the AMI to assign launch permissions to. | `string` | n/a | yes |
+| extraorg\_account\_ids | A list of AWS account IDs corresponding to "extra" accounts with which you want to share this AMI (e.g. ["123456789012"]).  Normally this variable is used to share an AMI with accounts that are not a member of the same AWS Organization as the account that owns the AMI. | `list(string)` | `[]` | no |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| accounts | A map whose keys are the account names allowed to launch the AMI and whose values are the account IDs and the AMI ID. |
+| accounts | A map whose keys are the IDs of the AWS accounts allowed to launch the AMI, and whose values are the aws\_ami\_launch\_permission resources for the corresponding launch permissions. |
 
 ## Notes ##
 

--- a/main.tf
+++ b/main.tf
@@ -11,11 +11,11 @@ data "aws_organizations_organization" "org" {
 # ------------------------------------------------------------------------------
 
 resource "aws_ami_launch_permission" "accounts" {
-  for_each = toset(distinct(concat([
+  for_each = toset(concat([
     for account in data.aws_organizations_organization.org.non_master_accounts :
     account.id
     if length(regexall(var.account_name_regex, account.name)) > 0
-  ], var.extraorg_account_ids)))
+  ], var.extraorg_account_ids))
 
   image_id   = var.ami_id
   account_id = each.value

--- a/main.tf
+++ b/main.tf
@@ -4,16 +4,18 @@ data "aws_organizations_organization" "org" {
 }
 
 # ------------------------------------------------------------------------------
-# Add launch permissions for all non-master accounts in the organization
-# whose names match the account_name_regex.
+# Add launch permissions for all non-master accounts in the
+# organization whose names match the account_name_regex, as well as
+# any extra-organizational account IDs listed in
+# var.extraorg-account_ids.
 # ------------------------------------------------------------------------------
 
 resource "aws_ami_launch_permission" "accounts" {
-  for_each = {
+  for_each = toset(distinct(concat([
     for account in data.aws_organizations_organization.org.non_master_accounts :
-    account.name => account.id
+    account.id
     if length(regexall(var.account_name_regex, account.name)) > 0
-  }
+  ], var.extraorg_account_ids)))
 
   image_id   = var.ami_id
   account_id = each.value

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "accounts" {
   value       = aws_ami_launch_permission.accounts
-  description = "A map whose keys are the account names allowed to launch the AMI and whose values are the account IDs and the AMI ID."
+  description = "A map whose keys are the IDs of the AWS accounts allowed to launch the AMI, and whose values are the aws_ami_launch_permission resources for the corresponding launch permissions."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,11 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-variable "account_name_regex" {
-  description = "A regular expression that will be applied against the names of all accounts in the AWS organization.  If the name of an account matches the regular expression, that account will be allowed to launch the specified AMI."
-  type        = string
-}
-
 variable "ami_id" {
   description = "The ID of the AMI to assign launch permissions to."
   type        = string
@@ -19,3 +14,15 @@ variable "ami_id" {
 #
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
+
+variable "account_name_regex" {
+  description = "A regular expression that will be applied against the names of all accounts in the AWS organization.  If the name of an account matches the regular expression, that account will be allowed to launch the specified AMI.  The default value should not match any valid account name."
+  type        = string
+  default     = "^$"
+}
+
+variable "extraorg_account_ids" {
+  type        = list(string)
+  description = "A list of AWS account IDs corresponding to \"extra\" accounts with which you want to share this AMI (e.g. [\"123456789012\"]).  Normally this variable is used to share an AMI with accounts that are not a member of the same AWS Organization as the account that owns the AMI."
+  default     = []
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds the ability to specify extra-organizational account IDs that can launch the AMI.
- Makes the default value for the account name regex `^$`, which should not match any valid account name.
- Makes the default value for the account name regex optional, so one can use the module to only create launch permissions for extra-organizational account IDs.

## 💭 Motivation and context ##

I require this change in order to allow the CEIL SharedServices account to use our OpenVPN and FreeIPA AMIs.

## 🧪 Testing ##

All GitHub Actions pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
